### PR TITLE
Add "files" key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   ],
   "author": "James Kyle <me@thejameskyle.com>",
   "license": "BSD-3-Clause",
+  "files": [
+    "index.js"
+  ],
   "dependencies": {
     "a11y-focus-scope": "^1.1.0",
     "a11y-focus-store": "^1.0.0",


### PR DESCRIPTION
I only listed `index.js`, because according to https://docs.npmjs.com/files/package.json:

> Certain files are always included, regardless of settings:
> - package.json
> - README (and its variants)
> - CHANGELOG (and its variants)
> - LICENSE / LICENCE

(closes #6)
